### PR TITLE
무릉 기록이 없는 경우 시드 기록이 표시되는 문제 해결

### DIFF
--- a/guildlist/guildlist.py
+++ b/guildlist/guildlist.py
@@ -1,21 +1,26 @@
 from bs4 import BeautifulSoup
+from urllib import parse
 import re
 import requests
 import time
 
+guild_name = '주장'
+guild_name_enc = parse.quote(guild_name)
+
 time1 = time.time()
-guild_page = requests.get('https://maple.gg/guild/elysium/%ED%9D%91%EB%AC%98/members?sort=level')
+guild_page = requests.get('https://maple.gg/guild/elysium/{}/members?sort=level'.format(guild_name_enc))
 time2 = time.time()
 soup = BeautifulSoup(guild_page.content, 'html.parser')
 time3 = time.time()
 guild_content = soup.find_all(class_ = 'col-lg-3 col-md-6 col-sm-6 mt-4')
 time4 = time.time()
 print(time4 - time3, time3 - time2, time2 - time1)
+
 csv_mode = True
 
 if(csv_mode):
-    csv_file = open("guild_list.csv", "w")
-    csv_file.write("닉네임,직업,레벨,최근 접속 일수,무릉층수,무릉시간\n")
+    csv_file = open('guild_list.csv', 'w')
+    csv_file.write('닉네임,직업,레벨,최근 접속 일수,무릉층수,무릉시간\n')
 
 for member in guild_content:
     nickname = member.find(class_ = re.compile('font-size-14 +')).get_text()
@@ -29,21 +34,23 @@ for member in guild_content:
     
     nick_url = 'https://maple.gg/u/' + nickname
     webpage = requests.get(nick_url)
-    nick_soup = BeautifulSoup(webpage.content, "html.parser")
-    floor = nick_soup.find(class_ = 'user-summary-floor font-weight-bold')
-    floor_time = nick_soup.find(class_ = 'user-summary-duration')
-    if(floor == None):
-        floor = '-'
-    else:
-        floor = int(floor.get_text()[:-1])
-    if(floor_time == None):
-        floor_time = '-'
-    else:
-        floor_time = floor_time.get_text()
+    nick_soup = BeautifulSoup(webpage.content, 'html.parser')
+
+    floor_info = nick_soup.find_all(class_ = 'col-lg-3 col-6 mt-3 px-1')[0]
+    no_floor_data = floor_info.find(class_ = 'user-summary-no-data')
+
+    floor = '-'
+    floor_time = '-'
+    if no_floor_data == None:
+        floor_value = floor_info.find(class_ = 'user-summary-floor font-weight-bold')
+        if(floor_value != None):
+            floor = int(floor_value.get_text()[:-1])
+
+        floor_time_value = floor_info.find(class_ = 'user-summary-duration')
+        if(floor_time_value != None):
+            floor_time = floor_time_value.get_text()
     
     if(csv_mode):
-        csv_file.write(nickname+','+ job +','+ level +','+ last_summary_date +\
-            ','+str(floor)+','+floor_time+'\n')
-    time5 = time.time()
+        csv_file.write('{},{},{},{},{},{}\n'.format(nickname, job, level, last_summary_date, str(floor), floor_time))
     
     

--- a/guildlist/guildlist.py
+++ b/guildlist/guildlist.py
@@ -4,7 +4,7 @@ import re
 import requests
 import time
 
-guild_name = '주장'
+guild_name = '흑묘'
 guild_name_enc = parse.quote(guild_name)
 
 time1 = time.time()


### PR DESCRIPTION
### 버그
- 무릉 기록이 없고 시드 기록은 있는 유저의 정보를 크롤링하는 경우, 시드 기록이 표시되는 문제가 있습니다.

### 수정사항
- 길드 이름을 한국어로 입력할 수 있게 수정했습니다. 
   - maple.gg 에 검색하여 주소를 복사하지 않아도 됩니다.
- 무릉 기록을 올바르게 가져옵니다.

### 테스트
#### Before
![image](https://user-images.githubusercontent.com/38686321/94806277-a649f600-0428-11eb-8c23-803eeae33060.png)


- 첫 번째 캐릭터 무릉 기록이 15분을 초과해 있습니다. 무릉 기록은 15분을 초과할 수 없습니다.

#### After
![image](https://user-images.githubusercontent.com/38686321/94806246-9a5e3400-0428-11eb-895c-d39cfa567685.png)

- 무릉 기록이 존재하지 않아 `-` 로 표시됩니다.
- 무릉 기록이 존재하는 유저들은 정상 표시됩니다.

